### PR TITLE
Update jquery.polyglot.language.switcher.js

### DIFF
--- a/js/jquery.polyglot.language.switcher.js
+++ b/js/jquery.polyglot.language.switcher.js
@@ -296,7 +296,7 @@
 
         function toLiElement(option) {
             var id = $(option).attr("id");
-            var value = $(option).attr("value");
+            var value = $(option).val();
             var text = $(option).text();
             var liElement;
             if (isStaticWebSite) {


### PR DESCRIPTION
fix attr('value') to val() for recent jQuery version
