### PR TITLE
Added centering for trigger arrow

### DIFF
--- a/css/polyglot-language-switcher.css
+++ b/css/polyglot-language-switcher.css
@@ -88,8 +88,10 @@ License URI: http://www.opensource.org/licenses/mit-license.php
 	width: 9px;
 	height: 5px;
 	text-indent: -10000em;
-	top: 0.5em; /* 6px */
+	top: 0;
+	bottom: 0;
 	right: 6px;
+	margin: auto;
 }
 
 #polyglotLanguageSwitcher a.current:link span.trigger, #polyglotLanguageSwitcher a.current:visited span.trigger {


### PR DESCRIPTION
I Added absolute centering for the trigger arrow so it does not rely on a magic number i.e. 0.5em which changes based on text.

Before fix:
![image](https://cloud.githubusercontent.com/assets/687730/5630218/65c768b6-95c4-11e4-8f61-a4efe185b8cf.png)

After:
![image](https://cloud.githubusercontent.com/assets/687730/5630240/95f3eb5e-95c4-11e4-8f8d-33dec5a96dc0.png)
